### PR TITLE
Add translatable strings for Import From File in System Admin

### DIFF
--- a/dbStringsForTranslation.php
+++ b/dbStringsForTranslation.php
@@ -453,6 +453,15 @@ __('Pacific/Wake');
 __('Pacific/Wallis');
 __('UTC');
 
+// System Admin - Import Fields
+__n('Markbook Column', 'Markbook Columns', 1);
+__n('Timetable Day', 'Timetable Days', 1);
+__n('Medical Form', 'Medical Forms', 1);
+__n('Special Day', 'Special Days', 1);
+__n('Column Row', 'Column Rows', 1);
+__n('Course', 'Courses', 1);
+__('Created By');
+
 //DYNAMIC: OVERWRITE FROM DATABASE
 //gibbonAction - category
 __('Activities') ;


### PR DESCRIPTION
The import definitions in YML contain a few strings that are not currently translated, but would be useful to add. I've included some of them in the `__n()` form, which we should be able to generate as pluralized strings via xgettext.