### PR TITLE
Fix slashes being added to translation strings

### DIFF
--- a/dbTranslationPrep.php
+++ b/dbTranslationPrep.php
@@ -125,7 +125,7 @@ foreach ($queries as $query) {
 
     // Trim out duplicate strings, then add slashes and output
     foreach (array_unique($strings) as $string) {
-        print "__('" . addslashes($string) . "');<br/>";
+        print "__('" . str_replace("'", "\'", $string) . "');<br/>";
     }
 
     print "<br/>" ;


### PR DESCRIPTION
Currently slashes are being added to strings, which causes unnecessary slashes showing up in POEditor. The strings are being output as string literals, so the only character we need to escape is the single quote.